### PR TITLE
Fix #100 - Disactivated and disabled auto detect server when custom

### DIFF
--- a/src/edu/usf/cutr/opentripplanner/android/SettingsActivity.java
+++ b/src/edu/usf/cutr/opentripplanner/android/SettingsActivity.java
@@ -352,6 +352,8 @@ public class SettingsActivity extends PreferenceActivity implements ServerChecke
 	public void onServerCheckerComplete(String result, boolean isWorking) {
 		SharedPreferences.Editor prefsEditor = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit();
 		if (isWorking){
+			autoDetectServer.setChecked(false);
+			autoDetectServer.setEnabled(false);
 			selectedCustomServer.setEnabled(true);
 			selectedCustomServer.setChecked(true);
 			returnIntent.putExtra(OTPApp.CHANGED_SELECTED_CUSTOM_SERVER_RETURN_KEY, true);


### PR DESCRIPTION
server is auto selected after enter a correct url.
