### PR TITLE
Fix #110 - Changed targetSdk to a previous level.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -19,7 +19,7 @@
     android:versionCode="8"
     android:versionName="2.0.1" >
     <uses-sdk android:minSdkVersion="8" 
-              android:targetSdkVersion="16"/>
+              android:targetSdkVersion="13"/>
     
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
This way is reactivated compatibility behavior, showing options button for devices without options physical button.
