### PR TITLE
Fix #119 - Servers updated each 3 days in the background.

### DIFF
--- a/src/edu/usf/cutr/opentripplanner/android/OTPApp.java
+++ b/src/edu/usf/cutr/opentripplanner/android/OTPApp.java
@@ -135,6 +135,8 @@ public class OTPApp extends Application {
 	
 	public static final String TAG = "OTP";
 	
+	public static final int EXPIRATION_DAYS_FOR_SERVER_LIST = 3;
+	
 	public static final float defaultZoomStep = 1;
 	public static final float defaultInitialZoomLevel = 12;
 	public static final float defaultMediumZoomLevel = 14;

--- a/src/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
+++ b/src/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
@@ -2885,10 +2885,10 @@ public class MainFragment extends Fragment implements
 		ServersDataSource dataSource = ServersDataSource.getInstance(applicationContext);
 		dataSource.open();
 		boolean result;
-		Calendar threeDaysBefore = Calendar.getInstance();
-		threeDaysBefore.add(Calendar.DAY_OF_MONTH, -3);
+		Calendar someDaysBefore = Calendar.getInstance();
+		someDaysBefore.add(Calendar.DAY_OF_MONTH, - OTPApp.EXPIRATION_DAYS_FOR_SERVER_LIST);
 		Long serversUpdateDate = dataSource.getMostRecentDate();
-		if ((serversUpdateDate != null) && (threeDaysBefore.getTime().getTime() > serversUpdateDate)){
+		if ((serversUpdateDate != null) && (someDaysBefore.getTime().getTime() > serversUpdateDate)){
 			result = false;
 		}
 		else{

--- a/src/edu/usf/cutr/opentripplanner/android/tasks/ServerSelector.java
+++ b/src/edu/usf/cutr/opentripplanner/android/tasks/ServerSelector.java
@@ -175,10 +175,10 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Long> implements 
 		dataSource.close();
 		
 		dataSource.open();
-		Calendar threeDaysBefore = Calendar.getInstance();
-		threeDaysBefore.add(Calendar.DAY_OF_MONTH, -3);
+		Calendar someDaysBefore = Calendar.getInstance();
+		someDaysBefore.add(Calendar.DAY_OF_MONTH, - OTPApp.EXPIRATION_DAYS_FOR_SERVER_LIST);
 		Long serversUpdateDate = dataSource.getMostRecentDate();
-		if ((serversUpdateDate != null) && (threeDaysBefore.getTime().getTime() > serversUpdateDate)){
+		if ((serversUpdateDate != null) && (someDaysBefore.getTime().getTime() > serversUpdateDate)){
 			servers = null;
 		}
 		dataSource.close();


### PR DESCRIPTION
This background way of trigger server auto-detection is also used now when auto-detecting server without user asking for it. Just a toast is shown if the server is changed.
