### PR TITLE
Fix #259 - Add continuous integration via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: java
+jdk: oraclejdk7
+
+before_install:
+    - chmod +x gradlew
+    - ANDROID_API_LEVEL=19
+    - ANDROID_SDK_TOOLS_VERSION=22.0.5
+    - ANDROID_BUILD_TOOLS_VERSION=19.0.1
+    - ANDROID_OS_VERSION=4.4.2
+
+    # Install Android SDK
+    - sudo apt-get update -qq
+    - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+    - wget https://dl.google.com/android/android-sdk_r$ANDROID_SDK_TOOLS_VERSION-linux.tgz
+    - tar xzf android-sdk_r$ANDROID_SDK_TOOLS_VERSION-linux.tgz
+    - export ANDROID_HOME=$PWD/android-sdk-linux
+    - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+
+    # Install Android build tools
+    - wget https://dl-ssl.google.com/android/repository/build-tools_r$ANDROID_BUILD_TOOLS_VERSION-linux.zip
+    - unzip build-tools_r$ANDROID_BUILD_TOOLS_VERSION-linux.zip -d $ANDROID_HOME
+    - mkdir -p $ANDROID_HOME/build-tools/
+    - mv $ANDROID_HOME/android-$ANDROID_OS_VERSION $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION
+
+    # Install Android SDK components
+    - echo y | android update sdk --filter platform-tools,build-tools-$ANDROID_BUILD_TOOLS_VERSION,android-$ANDROID_API_LEVEL,extra-android-m2repository,extra-android-support,extra-google-google_play_services,extra-google-m2repository --no-ui --force > /dev/null
+install:
+  - true
+script:
+    - TERM=dumb ./gradlew assembleDebug

--- a/opentripplanner-android/build.gradle
+++ b/opentripplanner-android/build.gradle
@@ -51,6 +51,10 @@ android {
         exclude 'META-INF/NOTICE'
     }
 
+    lintOptions {
+        disable 'MissingTranslation', 'ExtraTranslation'
+    }
+
     if (project.hasProperty("secure.properties")
             && new File(project.property("secure.properties")).exists()) {
 


### PR DESCRIPTION
This is a combination of 9 commits.
Initial Travis CI build script.  We'll see if this works.

Tweaks to see if this fixes problems.

Update to version numbers found in working .travis.yml here - https://github.com/yelinaung/Karrency/blob/master/.travis.yml

More tweaks.

Add Android Support package, more tweaks.

Match buildTools version in build.gradle.

Add Lint configuration to build.gradle to disable build fails due to "MissingTranslation" or "ExtraTranslation".

Add TERM=dumb, per https://github.com/yelinaung/Karrency/blob/master/.travis.yml to avoid compiling assembleRelease profile.

Add "install", per https://github.com/yelinaung/Karrency/blob/master/.travis.yml
