### PR TITLE
Update to Android Studio 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: oraclejdk7
 
 android:
   components:
-    - build-tools-19.0.3
+    - build-tools-19.1.0
 
 script:
   - ./gradlew assembleDebug -PdisablePreDex

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 26 17:17:04 EST 2014
+#Mon Jun 09 13:40:17 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/opentripplanner-android/build.gradle
+++ b/opentripplanner-android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.11.+'
     }
 }
 apply plugin: 'android'
@@ -38,7 +38,7 @@ repositories {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8


### PR DESCRIPTION
Requires update to 0.11 Android Gradle plugin, which requires 19.1.0 build tools.  Also bumps Gradle wrapper to 1.12.
