### PR TITLE
Fix #309 - NPE when database is empty on app update

### DIFF
--- a/opentripplanner-android/src/main/AndroidManifest.xml
+++ b/opentripplanner-android/src/main/AndroidManifest.xml
@@ -16,10 +16,10 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="edu.usf.cutr.opentripplanner.android"
-          android:versionCode="12"
-          android:versionName="2.0.5">
+    android:versionCode="13"
+    android:versionName="2.1.0">
 
-    <uses-sdk
+<uses-sdk
             android:minSdkVersion="8"
             android:targetSdkVersion="13"/>
 

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/OTPApp.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/OTPApp.java
@@ -226,6 +226,8 @@ public class OTPApp extends Application {
 
     public static final String PREFERENCE_KEY_APP_VERSION = "app_version";
 
+    public static final String PREFERENCE_KEY_EXECUTED_VERSION_CODE_13 = "executed_version_13";
+
     private static Server selectedServer;
 
     public static final String TAG = "OTP";

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
@@ -2519,7 +2519,7 @@ public class MainFragment extends Fragment implements
 
             Log.v(OTPApp.TAG, "Now using OTP server: " + server.getRegion());
         } else {
-            Log.v(OTPApp.TAG, "Server not selected yet, should be first start");
+            Log.v(OTPApp.TAG, "Server not selected yet, should be first start or app update");
             return;
         }
         if (server.getOffersBikeRental()){
@@ -4013,11 +4013,20 @@ public class MainFragment extends Fragment implements
             editor.commit();
             mNewAppVersion = newVersionCode != oldVersionCode;
 
-            if (mNewAppVersion) {
+            /**
+             * Special handling for introduction of PREFERENCE_KEY_APP_VERSION - see #309
+             * Otherwise, mNewVersion will be false the first time we execute version_code 13
+             * when installed as an update to version_code 12.
+             */
+            boolean executedVersion13 = mPrefs.getBoolean(OTPApp.PREFERENCE_KEY_EXECUTED_VERSION_CODE_13, false);
+
+            if (mNewAppVersion || !executedVersion13) {
                 Log.d(OTPApp.TAG, "Updating from app version " + oldVersionCode + " to " +
                         newVersionCode);
                 // Erase selected server, so server selection is run after an app update (#309)
                 editor.putLong(OTPApp.PREFERENCE_KEY_SELECTED_SERVER, 0);
+                // We've executed version_code 13 or higher once, so set the preference
+                editor.putBoolean(OTPApp.PREFERENCE_KEY_EXECUTED_VERSION_CODE_13, true);
                 editor.commit();
             }
         } catch (PackageManager.NameNotFoundException e) {


### PR DESCRIPTION
- Move check for new app version to MainFragment.onActivityCreated(), so it is completed earlier in the Fragment lifecycle, before onStart().  onStart() connects to Google Play Services, so onConnected() (where we need to know if the app is a new version) can be triggered by callback from Google Play Services at any point after onStart().
- Reset OTPApp.PREFERENCE_KEY_SELECTED_SERVER if a new app version is detected in MainFragment.onActivityCreated()
- Check for the first execution of version_code 13 or higher, due to introduction of new OTPApp.PREFERENCE_KEY_APP_VERSION preference
- Bumps app version_code and version
