### PR TITLE
convert AsyncTasks to IntentService 

### DIFF
--- a/opentripplanner-android/src/main/AndroidManifest.xml
+++ b/opentripplanner-android/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
 
         <service android:name=".tasks.MetadataRequest" android:exported="false"/>
         <service android:name=".tasks.OTPGeocoding" android:exported="false"/>
+        <service android:name=".tasks.ServerSelector" android:exported="false"/>
 
         <meta-data
                 android:name="com.google.android.maps.v2.API_KEY"

--- a/opentripplanner-android/src/main/AndroidManifest.xml
+++ b/opentripplanner-android/src/main/AndroidManifest.xml
@@ -70,6 +70,7 @@
                 android:windowSoftInputMode="stateHidden"></activity>
 
         <service android:name=".tasks.MetadataRequest" android:exported="false"/>
+        <service android:name=".tasks.OTPGeocoding" android:exported="false"/>
 
         <meta-data
                 android:name="com.google.android.maps.v2.API_KEY"

--- a/opentripplanner-android/src/main/AndroidManifest.xml
+++ b/opentripplanner-android/src/main/AndroidManifest.xml
@@ -69,6 +69,8 @@
                 android:theme="@style/MyTheme"
                 android:windowSoftInputMode="stateHidden"></activity>
 
+        <service android:name=".tasks.MetadataRequest" android:exported="false"/>
+
         <meta-data
                 android:name="com.google.android.maps.v2.API_KEY"
                 android:value="AIzaSyD5XadJhAK7jIKFz5TcT7t-gsWw_OTvlBI"/>

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
@@ -169,6 +169,7 @@ import edu.usf.cutr.opentripplanner.android.tasks.OTPGeocoding.OTPGeocodingRecei
 import edu.usf.cutr.opentripplanner.android.tasks.RequestTimesForTrips;
 import edu.usf.cutr.opentripplanner.android.tasks.ServerChecker;
 import edu.usf.cutr.opentripplanner.android.tasks.ServerSelector;
+import edu.usf.cutr.opentripplanner.android.tasks.ServerSelector.ServerSelectorReceiver;
 import edu.usf.cutr.opentripplanner.android.tasks.TripRequest;
 import edu.usf.cutr.opentripplanner.android.util.BikeRentalStationInfo;
 import edu.usf.cutr.opentripplanner.android.util.ConversionUtils;
@@ -198,6 +199,8 @@ public class MainFragment extends Fragment implements
         GooglePlayServicesClient.ConnectionCallbacks,
         GoogleMap.OnCameraChangeListener {
 
+    public static final String SERVERSELECTOR_FILTER = "MainFragment_mServerSelectorReceiver";
+    public static final String SERVERSELECTOR_NOLOCATION_FILTER = "MainFragment_mServerSelectorReceiverNoLocation";
     public static final String METADATA_FILTER = "MainFragment_metadatRequestReceiver";
     public static final String OTPGEOCODING_FILTER = "MainFragment_otpGeocodingReceiver";
 
@@ -368,6 +371,10 @@ public class MainFragment extends Fragment implements
 
     private OTPGeocodingReceiver mOtpGeocodingReceiver;
 
+    private ServerSelectorReceiver mServerSelectorReceiver;
+
+    private ServerSelectorReceiver mServerSelectorReceiverNoLocation;
+
     @SuppressWarnings("deprecation")
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     private static void removeOnGlobalLayoutListener(View v,
@@ -417,6 +424,12 @@ public class MainFragment extends Fragment implements
         }
         if (mOtpGeocodingReceiver != null) {
             LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mOtpGeocodingReceiver);
+        }
+        if (mServerSelectorReceiver != null) {
+            LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mServerSelectorReceiver);
+        }
+        if (mServerSelectorReceiverNoLocation != null) {
+            LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mServerSelectorReceiverNoLocation);
         }
     }
 
@@ -2109,11 +2122,16 @@ public class MainFragment extends Fragment implements
                     Toast.LENGTH_LONG).show();
         } else {
             ServersDataSource dataSource = ServersDataSource.getInstance(mApplicationContext);
-            WeakReference<Activity> weakContext = new WeakReference<Activity>(getActivity());
-
-            ServerSelector serverSelector = new ServerSelector(weakContext, mApplicationContext,
-                    dataSource, this, mNeedToUpdateServersList, showDialog);
-            serverSelector.execute(mCurrentLatLng);
+            mServerSelectorReceiver = new ServerSelectorReceiver(getActivity(), mApplicationContext,
+                    dataSource, this, showDialog);
+            LocalBroadcastManager.getInstance(getActivity()).registerReceiver(mServerSelectorReceiver,
+                    new IntentFilter(SERVERSELECTOR_FILTER));
+            Intent serverSelector = new Intent(getActivity(), ServerSelector.class);
+            mServerSelectorReceiver.showProgressDialog();
+            serverSelector.putExtra("latLng", mCurrentLatLng);
+            serverSelector.putExtra("mustRefreshList", mNeedToUpdateServersList);
+            serverSelector.putExtra("FILTER", SERVERSELECTOR_FILTER);
+            getActivity().startService(serverSelector);
             mSavedLastLocationCheckedForServer = mCurrentLatLng;
         }
         setNeedToRunAutoDetect(false);
@@ -2130,13 +2148,16 @@ public class MainFragment extends Fragment implements
      */
     public void runAutoDetectServerNoLocation(boolean showDialog) {
         ServersDataSource dataSource = ServersDataSource.getInstance(mApplicationContext);
-        WeakReference<Activity> weakContext = new WeakReference<Activity>(getActivity());
+        mServerSelectorReceiverNoLocation = new ServerSelectorReceiver(getActivity(), mApplicationContext,
+                dataSource, this, showDialog);
+        LocalBroadcastManager.getInstance(getActivity())
+            .registerReceiver(mServerSelectorReceiverNoLocation, new IntentFilter(SERVERSELECTOR_NOLOCATION_FILTER));
+        Intent serverSelector = new Intent(getActivity(), ServerSelector.class);
+        mServerSelectorReceiverNoLocation.showProgressDialog();
+        serverSelector.putExtra("mustRefreshList", mNeedToUpdateServersList);
+        serverSelector.putExtra("FILTER", SERVERSELECTOR_NOLOCATION_FILTER);
+        getActivity().startService(serverSelector);
 
-        ServerSelector serverSelector = new ServerSelector(weakContext, mApplicationContext,
-                dataSource, this, mNeedToUpdateServersList, showDialog);
-        LatLng latLngList[] = new LatLng[1];
-        latLngList[0] = null;
-        serverSelector.execute(latLngList);
         setNeedToRunAutoDetect(false);
         setNeedToUpdateServersList(false);
     }

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
@@ -53,6 +53,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v4.widget.DrawerLayout.DrawerListener;
 import android.text.Editable;
@@ -162,6 +163,7 @@ import edu.usf.cutr.opentripplanner.android.model.Server;
 import edu.usf.cutr.opentripplanner.android.sqlite.ServersDataSource;
 import edu.usf.cutr.opentripplanner.android.tasks.BikeRentalLoad;
 import edu.usf.cutr.opentripplanner.android.tasks.MetadataRequest;
+import edu.usf.cutr.opentripplanner.android.tasks.MetadataRequest.MetadataRequestReceiver;
 import edu.usf.cutr.opentripplanner.android.tasks.OTPGeocoding;
 import edu.usf.cutr.opentripplanner.android.tasks.RequestTimesForTrips;
 import edu.usf.cutr.opentripplanner.android.tasks.ServerChecker;
@@ -194,6 +196,8 @@ public class MainFragment extends Fragment implements
         GooglePlayServicesClient.OnConnectionFailedListener,
         GooglePlayServicesClient.ConnectionCallbacks,
         GoogleMap.OnCameraChangeListener {
+
+    public static final String METADATA_FILTER = "MainFragment_metadatRequestReceiver";
 
     private static LocationManager sLocationManager;
 
@@ -360,6 +364,8 @@ public class MainFragment extends Fragment implements
 
     private OTPGeocoding mGeoCodingTask;
 
+    private MetadataRequestReceiver mMetadatRequestReceiver;
+
     @SuppressWarnings("deprecation")
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     private static void removeOnGlobalLayoutListener(View v,
@@ -395,6 +401,17 @@ public class MainFragment extends Fragment implements
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString()
                     + " must implement OtpFragment");
+        }
+        mMetadatRequestReceiver = new MetadataRequestReceiver(activity, activity.getApplicationContext(), this);
+        LocalBroadcastManager.getInstance(activity)
+            .registerReceiver(mMetadatRequestReceiver, new IntentFilter(METADATA_FILTER));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        if (mMetadatRequestReceiver != null) {
+            LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mMetadatRequestReceiver);
         }
     }
 
@@ -2651,9 +2668,11 @@ public class MainFragment extends Fragment implements
                 WeakReference<Activity> weakContext = new WeakReference<Activity>(getActivity());
 
                 if (mCustomServerMetadata == null){
-                    MetadataRequest metaRequest = new MetadataRequest(weakContext, mApplicationContext,
-                            this);
-                    metaRequest.execute(mPrefs.getString(OTPApp.PREFERENCE_KEY_CUSTOM_SERVER_URL, ""));
+                    Intent metaRequest = new Intent(getActivity(), MetadataRequest.class);
+                    mMetadatRequestReceiver.showProgressDialog();
+                    metaRequest.putExtra("reqs", mPrefs.getString(OTPApp.PREFERENCE_KEY_CUSTOM_SERVER_URL, ""));
+                    metaRequest.putExtra("FILTER", METADATA_FILTER);
+                    getActivity().startService(metaRequest);
                 }
                 else{
                     onMetadataRequestComplete(mCustomServerMetadata, false);

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/model/Server.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/model/Server.java
@@ -26,7 +26,9 @@ import edu.usf.cutr.opentripplanner.android.exceptions.ServerListParsingExceptio
  * Modified by Khoa Tran
  */
 
-public class Server {
+public class Server implements java.io.Serializable {
+
+    private static final long serialVersionUID = 7306023856160948263L;
 
     private long id;
 

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/ServerSelector.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/ServerSelector.java
@@ -18,12 +18,15 @@ package edu.usf.cutr.opentripplanner.android.tasks;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.IntentService;
 import android.app.ProgressDialog;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.AsyncTask;
 import android.preference.PreferenceManager;
+import android.support.v4.content.LocalBroadcastManager;
 import android.text.Editable;
 import android.util.Log;
 import android.webkit.URLUtil;
@@ -68,72 +71,28 @@ import static edu.usf.cutr.opentripplanner.android.OTPApp.PREFERENCE_KEY_SELECTE
  * @author Khoa Tran
  */
 
-public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
-        implements ServerCheckerCompleteListener {
-
+public class ServerSelector extends IntentService {
     private Server selectedServer;
-
-    private ProgressDialog progressDialog;
-
-    private WeakReference<Activity> activity;
-
-    private Context context;
-
+    private boolean mustRefreshList;
+    private boolean isAutoDetectEnabled;
     private static List<Server> knownServers = new ArrayList<Server>();
+    private ServersDataSource dataSource;
 
-    private boolean mustRefreshList = false;
-
-    private boolean isAutoDetectEnabled = true;
-
-    private ServerSelectorCompleteListener callback;
-
-    private boolean selectedCustomServer;
-
-    private boolean showDialog;
-
-    public ServersDataSource dataSource = null;
-
-    /**
-     * Constructs a new ServerSelector
-     *
-     * @param mustRefreshList true if we should download a new list of servers from the Google
-     *                        Doc, false if we should use cached list of servers
-     * @param showDialog      true if a progress dialog is requested
-     */
-    public ServerSelector(WeakReference<Activity> activity, Context context,
-            ServersDataSource dataSource, ServerSelectorCompleteListener callback,
-            boolean mustRefreshList, boolean showDialog) {
-        this.activity = activity;
-        this.context = context;
-        this.dataSource = dataSource;
-        this.callback = callback;
-        this.mustRefreshList = mustRefreshList;
-        this.showDialog = showDialog;
-        Activity activityRetrieved = activity.get();
-        if ((activityRetrieved != null) && showDialog) {
-            progressDialog = new ProgressDialog(activityRetrieved);
-        }
+    public ServerSelector() {
+        super("ServerSelector");
     }
 
-    protected void onPreExecute() {
-        Activity activityRetrieved = activity.get();
-        if ((activityRetrieved != null) && showDialog) {
-            progressDialog.setIndeterminate(true);
-            progressDialog.setCancelable(true);
-            progressDialog = ProgressDialog.show(activityRetrieved, "",
-                    context.getResources().getString(R.string.task_progress_server_selector_progress), true);
-        }
-
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-
-        isAutoDetectEnabled = prefs.getBoolean(OTPApp.PREFERENCE_KEY_AUTO_DETECT_SERVER,
-                true);
+    private void init(Intent intent) {
+        this.mustRefreshList = intent.getBooleanExtra("mustRefreshList", false);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        isAutoDetectEnabled = prefs.getBoolean(OTPApp.PREFERENCE_KEY_AUTO_DETECT_SERVER, true);
     }
 
-
-    protected Integer doInBackground(LatLng... latLng) {
-        LatLng currentLocation = latLng[0];
-
+    public void onHandleIntent(Intent intent) {
+        init(intent);
+        LatLng latLng = (LatLng) intent.getParcelableExtra("latLng");
+        dataSource = ServersDataSource.getInstance(getApplicationContext());
+        LatLng currentLocation = latLng;
         List<Server> serverList = null;
 
         // If not forced to refresh list
@@ -149,7 +108,7 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
             Log.d(OTPApp.TAG,
                     "No data from sqlite. Attempt retrieving servers from google spreadsheet");
             serverList = downloadServerList(
-                    context.getResources().getString(R.string.servers_spreadsheet_url));
+                    getResources().getString(R.string.servers_spreadsheet_url));
 
             // Insert new list to database
             if (serverList != null && !serverList.isEmpty()) {
@@ -159,10 +118,12 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
 
             // If still null
             if (serverList == null || serverList.isEmpty()) {
-                return null;
+                Intent resultIntent = new Intent(intent.getStringExtra("FILTER"));
+                resultIntent.putExtra("selectedServer", selectedServer);
+                LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+                return;
             }
         }
-
         knownServers.clear();
         knownServers.addAll(serverList);
 
@@ -171,7 +132,21 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
             selectedServer = findOptimalSever(currentLocation);
         }
 
-        return serverList.size();
+        Intent resultIntent = new Intent(
+                intent.getStringExtra("return_action"));
+        resultIntent.putExtra("serverListSize", serverList.size());
+        resultIntent.putExtra("selectedServer", selectedServer);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+    }
+
+    private void insertServerListToDatabase(List<Server> servers) {
+        dataSource.open();
+        for (Server server : servers) {
+            if (dataSource.createServer(server) == null) {
+                Log.e(OTPApp.TAG, "Some server fields are incorrect, server not added");
+            }
+        }
+        dataSource.close();
     }
 
     private List<Server> getServersFromSQLite() {
@@ -196,7 +171,7 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
             servers = null;
         }
         dataSource.close();
-//		Toast.makeText(activity.getApplicationContext(), shown, Toast.LENGTH_SHORT).show();
+//    Toast.makeText(activity.getApplicationContext(), shown, Toast.LENGTH_SHORT).show();
 
         return servers;
     }
@@ -288,16 +263,6 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
 
     }
 
-    private void insertServerListToDatabase(List<Server> servers) {
-        dataSource.open();
-        for (Server server : servers) {
-            if (dataSource.createServer(server) == null) {
-                Log.e(OTPApp.TAG, "Some server fields are incorrect, server not added");
-            }
-        }
-        dataSource.close();
-    }
-
     /**
      * Automatically detects the correct OTP server based on the location of the device
      *
@@ -330,42 +295,86 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
         return server;
     }
 
-    protected void onPostExecute(Integer result) {
-        if ((activity.get() != null) && showDialog) {
-            try {
-                if (progressDialog != null && progressDialog.isShowing()) {
-                    progressDialog.dismiss();
-                }
-            } catch (Exception e) {
-                Log.e(OTPApp.TAG, "Error in Server Selector PostExecute dismissing dialog: " + e);
+    public static class ServerSelectorReceiver extends BroadcastReceiver
+            implements ServerCheckerCompleteListener {
+        private Server selectedServer;
+
+        private ProgressDialog progressDialog;
+
+        private Activity activity;
+
+        private Context context;
+
+        private ServerSelectorCompleteListener callback;
+
+        private boolean selectedCustomServer;
+
+        private boolean showDialog;
+
+        public ServersDataSource dataSource = null;
+
+        /**
+         * Constructs a new ServerSelector
+         *
+         * @param mustRefreshList true if we should download a new list of servers from the Google
+         *                        Doc, false if we should use cached list of servers
+         * @param showDialog      true if a progress dialog is requested
+         */
+        public ServerSelectorReceiver(Activity activity, Context context,
+                ServersDataSource dataSource, ServerSelectorCompleteListener callback, boolean showDialog) {
+            this.activity = activity;
+            this.context = context;
+            this.dataSource = dataSource;
+            this.callback = callback;
+            this.showDialog = showDialog;
+            this.progressDialog = new ProgressDialog(activity);
+        }
+
+        public void showProgressDialog() {
+            if (showDialog) {
+                progressDialog.setIndeterminate(true);
+                progressDialog.setCancelable(true);
+                progressDialog = ProgressDialog.show(activity, "",
+                        context.getResources().getString(R.string.task_progress_server_selector_progress), true);
             }
         }
 
-        if (selectedServer != null) {
-            //We've already auto-selected a server
-            ServerChecker serverChecker = new ServerChecker(activity,
-                    context, ServerSelector.this, false, false, true);
-            serverChecker.execute(selectedServer);
-        } else if (knownServers != null && !knownServers.isEmpty()) {
-            Log.d(OTPApp.TAG,
-                    "No server automatically selected.  User will need to choose the OTP server.");
 
-            // Create dialog for user to choose
-            List<String> serverNames = new ArrayList<String>();
-            for (Server server : knownServers) {
-                serverNames.add(server.getRegion());
+        public void onReceive(Context receiverContext, Intent receiverIntent) {
+            Integer result = (Integer) receiverIntent.getSerializableExtra("serverListSize");
+            selectedServer = (Server) receiverIntent.getSerializableExtra("selectedServer");
+            if (showDialog) {
+                try {
+                    if (progressDialog != null && progressDialog.isShowing()) {
+                        progressDialog.dismiss();
+                    }
+                } catch (Exception e) {
+                    Log.e(OTPApp.TAG, "Error in Server Selector PostExecute dismissing dialog: " + e);
+                }
             }
 
-            Collections.sort(serverNames);
+            if (selectedServer != null) {
+                //We've already auto-selected a server
+                ServerChecker serverChecker = new ServerChecker(new WeakReference<Activity>(activity),
+                        context, ServerSelectorReceiver.this, false, false, true);
+                serverChecker.execute(selectedServer);
+            } else if (knownServers != null && !knownServers.isEmpty()) {
+                Log.d(OTPApp.TAG,
+                        "No server automatically selected.  User will need to choose the OTP server.");
 
-            serverNames.add(0, context.getResources().getString(R.string.server_checker_info_custom_server_name));
+                // Create dialog for user to choose
+                List<String> serverNames = new ArrayList<String>();
+                for (Server server : knownServers) {
+                    serverNames.add(server.getRegion());
+                }
 
-            final CharSequence[] items = serverNames.toArray(new CharSequence[serverNames.size()]);
+                Collections.sort(serverNames);
 
-            Activity activityRetrieved = activity.get();
+                serverNames.add(0, context.getResources().getString(R.string.server_checker_info_custom_server_name));
 
-            if (activityRetrieved != null) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(activityRetrieved);
+                final CharSequence[] items = serverNames.toArray(new CharSequence[serverNames.size()]);
+
+                AlertDialog.Builder builder = new AlertDialog.Builder(activity);
                 builder.setTitle(context.getResources()
                         .getString(R.string.server_checker_info_title));
                 builder.setItems(items, new DialogInterface.OnClickListener() {
@@ -378,68 +387,63 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
                             SharedPreferences prefs = PreferenceManager
                                     .getDefaultSharedPreferences(context);
 
-                            Activity activityRetrieved = activity.get();
+                            final EditText tbBaseURL = new EditText(activity);
+                            String actualCustomServer = prefs
+                                    .getString(PREFERENCE_KEY_CUSTOM_SERVER_URL, "");
+                            tbBaseURL.setText(actualCustomServer);
 
-                            if (activityRetrieved != null) {
-                                final EditText tbBaseURL = new EditText(activityRetrieved);
-                                String actualCustomServer = prefs
-                                        .getString(PREFERENCE_KEY_CUSTOM_SERVER_URL, "");
-                                tbBaseURL.setText(actualCustomServer);
+                            AlertDialog.Builder urlAlert = new AlertDialog.Builder(activity);
+                            urlAlert.setTitle(context.getResources()
+                                    .getString(
+                                            R.string.server_selector_custom_server_alert_title));
+                            urlAlert.setView(tbBaseURL);
+                            urlAlert.setPositiveButton(
+                                    context.getResources().getString(android.R.string.ok),
+                                    new DialogInterface.OnClickListener() {
+                                        public void onClick(DialogInterface dialog,
+                                                int whichButton) {
+                                            Editable tbEditable = tbBaseURL.getText();
+                                            if (tbEditable != null) {
+                                                String value = tbEditable.toString().trim();
+                                                if (URLUtil.isValidUrl(value)) {
+                                                    SharedPreferences.Editor prefsEditor
+                                                            = PreferenceManager
+                                                            .getDefaultSharedPreferences(
+                                                                    context)
+                                                            .edit();
+                                                    prefsEditor
+                                                            .putString(
+                                                                    PREFERENCE_KEY_CUSTOM_SERVER_URL,
+                                                                    value);
 
-                                AlertDialog.Builder urlAlert = new AlertDialog.Builder(
-                                        activityRetrieved);
-                                urlAlert.setTitle(context.getResources()
-                                        .getString(
-                                                R.string.server_selector_custom_server_alert_title));
-                                urlAlert.setView(tbBaseURL);
-                                urlAlert.setPositiveButton(
-                                        context.getResources().getString(android.R.string.ok),
-                                        new DialogInterface.OnClickListener() {
-                                            public void onClick(DialogInterface dialog,
-                                                    int whichButton) {
-                                                Editable tbEditable = tbBaseURL.getText();
-                                                if (tbEditable != null) {
-                                                    String value = tbEditable.toString().trim();
-                                                    if (URLUtil.isValidUrl(value)) {
-                                                        SharedPreferences.Editor prefsEditor
-                                                                = PreferenceManager
-                                                                .getDefaultSharedPreferences(
-                                                                        context)
-                                                                .edit();
-                                                        prefsEditor
-                                                                .putString(
-                                                                        PREFERENCE_KEY_CUSTOM_SERVER_URL,
-                                                                        value);
-
-                                                        ServerChecker serverChecker
-                                                                = new ServerChecker(activity,
-                                                                context, ServerSelector.this, true,
-                                                                true, false);
-                                                        serverChecker.execute(
-                                                                new Server(value, context));
-                                                        prefsEditor.commit();
-                                                    } else {
-                                                        Toast.makeText(context,
-                                                                context.getResources()
-                                                                        .getString(
-                                                                                R.string.settings_menu_custom_server_url_description_error_url),
-                                                                Toast.LENGTH_SHORT).show();
-                                                    }
+                                                    ServerChecker serverChecker
+                                                            = new ServerChecker(new WeakReference<Activity>(activity),
+                                                            context, ServerSelectorReceiver.this, true,
+                                                            true, false);
+                                                    serverChecker.execute(
+                                                            new Server(value, context));
+                                                    prefsEditor.commit();
+                                                } else {
+                                                    Toast.makeText(context,
+                                                            context.getResources()
+                                                                   .getString(
+                                                                            R.string.settings_menu_custom_server_url_description_error_url),
+                                                            Toast.LENGTH_SHORT).show();
                                                 }
-
                                             }
-                                        });
-                                selectedCustomServer = true;
-                                urlAlert.create().show();
-                            }
+
+                                        }
+                                 });
+                            selectedCustomServer = true;
+                            urlAlert.create().show();
                         } else {
                             //User picked server from the list
                             for (Server server : knownServers) {
                                 //If this server region matches what the user picked, then set the server as the selected server
                                 if (server.getRegion().equals(items[item])) {
                                     selectedServer = server;
-                                    ServerChecker serverChecker = new ServerChecker(activity,
-                                            context, ServerSelector.this, false, false, false);
+                                    ServerChecker serverChecker = new ServerChecker(new WeakReference<Activity>(activity),
+                                            context, ServerSelectorReceiver.this, false, false, false);
                                     serverChecker.execute(selectedServer);
                                     break;
                                 }
@@ -449,76 +453,76 @@ public class ServerSelector extends AsyncTask<LatLng, Integer, Integer>
                     }
                 });
                 builder.show();
-            }
-        } else {
-            Log.e(OTPApp.TAG, "Server list could not be downloaded!!");
-            Toast.makeText(context,
-                    context.getResources().getString(R.string.toast_server_selector_refresh_server_list_error),
-                    Toast.LENGTH_SHORT).show();
-        }
-    }
-
-    @Override
-    public void onServerCheckerComplete(String result, boolean isCustomServer,
-            boolean isAutoDetected, boolean isWorking) {
-        SharedPreferences prefs = PreferenceManager
-                .getDefaultSharedPreferences(context);
-        SharedPreferences.Editor prefsEditor = prefs.edit();
-        if (isCustomServer){
-            if (isWorking) {
-                prefsEditor.putBoolean(PREFERENCE_KEY_AUTO_DETECT_SERVER, false);
-                prefsEditor.putBoolean(PREFERENCE_KEY_SELECTED_CUSTOM_SERVER, true);
-                prefsEditor.putBoolean(PREFERENCE_KEY_CUSTOM_SERVER_URL_IS_VALID, true);
-                prefsEditor.commit();
-                if (selectedCustomServer) {
-                    String baseURL = prefs.getString(PREFERENCE_KEY_CUSTOM_SERVER_URL, "");
-                    selectedServer = new Server(baseURL, context);
-                    callback.onServerSelectorComplete(selectedServer);
-                }
             } else {
-                prefsEditor.putBoolean(PREFERENCE_KEY_CUSTOM_SERVER_URL_IS_VALID, false);
-                prefsEditor.putBoolean(PREFERENCE_KEY_SELECTED_CUSTOM_SERVER, false);
-                prefsEditor.commit();
+                Log.e(OTPApp.TAG, "Server list could not be downloaded!!");
                 Toast.makeText(context,
-                        context.getResources().getString(R.string.toast_server_checker_error_bad_url),
+                        context.getResources().getString(R.string.toast_server_selector_refresh_server_list_error),
                         Toast.LENGTH_SHORT).show();
             }
         }
-        else{
-            if (isWorking){
-                if (isAutoDetected){
-                    long serverId = prefs.getLong(OTPApp.PREFERENCE_KEY_SELECTED_SERVER, 0);
-                    Server s = null;
-                    boolean serverIsChanged = true;
-                    if (serverId != 0) {
-                        dataSource.open();
-                        s = dataSource.getServer(prefs.getLong(OTPApp.PREFERENCE_KEY_SELECTED_SERVER, 0));
-                        dataSource.close();
+
+        @Override
+        public void onServerCheckerComplete(String result, boolean isCustomServer,
+                boolean isAutoDetected, boolean isWorking) {
+            SharedPreferences prefs = PreferenceManager
+                    .getDefaultSharedPreferences(context);
+            SharedPreferences.Editor prefsEditor = prefs.edit();
+            if (isCustomServer){
+                if (isWorking) {
+                    prefsEditor.putBoolean(PREFERENCE_KEY_AUTO_DETECT_SERVER, false);
+                    prefsEditor.putBoolean(PREFERENCE_KEY_SELECTED_CUSTOM_SERVER, true);
+                    prefsEditor.putBoolean(PREFERENCE_KEY_CUSTOM_SERVER_URL_IS_VALID, true);
+                    prefsEditor.commit();
+                    if (selectedCustomServer) {
+                        String baseURL = prefs.getString(PREFERENCE_KEY_CUSTOM_SERVER_URL, "");
+                        selectedServer = new Server(baseURL, context);
+                        callback.onServerSelectorComplete(selectedServer);
                     }
-                    if (s != null) {
-                        serverIsChanged = !(s.getRegion().equals(selectedServer.getRegion()));
-                    }
-                    if (showDialog || serverIsChanged) {
-                        Toast.makeText(context,
-                                context.getResources()
-                                        .getString(R.string.toast_server_selector_detected) + " "
-                                        + selectedServer.getRegion() + ". " + context.getResources()
-                                        .getString(R.string.toast_server_selector_server_change_info),
-                                Toast.LENGTH_SHORT).show();
-                    }
+                } else {
+                    prefsEditor.putBoolean(PREFERENCE_KEY_CUSTOM_SERVER_URL_IS_VALID, false);
+                    prefsEditor.putBoolean(PREFERENCE_KEY_SELECTED_CUSTOM_SERVER, false);
+                    prefsEditor.commit();
+                    Toast.makeText(context,
+                            context.getResources().getString(R.string.toast_server_checker_error_bad_url),
+                            Toast.LENGTH_SHORT).show();
                 }
-                prefsEditor.putLong(PREFERENCE_KEY_SELECTED_SERVER,
-                        selectedServer.getId());
-                prefsEditor.putBoolean(PREFERENCE_KEY_SELECTED_CUSTOM_SERVER, false);
-                prefsEditor.commit();
-                callback.onServerSelectorComplete(selectedServer);
             }
             else{
-                Toast.makeText(context,
-                        context.getResources()
-                                .getString(R.string.
-                                        toast_server_checker_error_unreachable_detected_server),
-                        Toast.LENGTH_SHORT).show();
+                if (isWorking){
+                    if (isAutoDetected){
+                        long serverId = prefs.getLong(OTPApp.PREFERENCE_KEY_SELECTED_SERVER, 0);
+                        Server s = null;
+                        boolean serverIsChanged = true;
+                        if (serverId != 0) {
+                            dataSource.open();
+                            s = dataSource.getServer(prefs.getLong(OTPApp.PREFERENCE_KEY_SELECTED_SERVER, 0));
+                            dataSource.close();
+                        }
+                        if (s != null) {
+                            serverIsChanged = !(s.getRegion().equals(selectedServer.getRegion()));
+                        }
+                        if (showDialog || serverIsChanged) {
+                            Toast.makeText(context,
+                                    context.getResources()
+                                            .getString(R.string.toast_server_selector_detected) + " "
+                                            + selectedServer.getRegion() + ". " + context.getResources()
+                                            .getString(R.string.toast_server_selector_server_change_info),
+                                    Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                    prefsEditor.putLong(PREFERENCE_KEY_SELECTED_SERVER,
+                            selectedServer.getId());
+                    prefsEditor.putBoolean(PREFERENCE_KEY_SELECTED_CUSTOM_SERVER, false);
+                    prefsEditor.commit();
+                    callback.onServerSelectorComplete(selectedServer);
+                }
+                else{
+                    Toast.makeText(context,
+                            context.getResources()
+                                    .getString(R.string.
+                                            toast_server_checker_error_unreachable_detected_server),
+                            Toast.LENGTH_SHORT).show();
+                }
             }
         }
     }


### PR DESCRIPTION
Hi `OpenTripPlanner-for-Android` developers, I'm doing research on Android async programming, particularly on AsyncTask and IntentService. AsyncTask can lead to memory leak and losing task result when GUI is recreated during task running (such as orientation change). [This article](http://bon-app-etit.blogspot.com/2013/04/the-dark-side-of-asynctask.html) describes the problems very well. 

We discussed with some Android experts and they agree with this issue, and claim that AsyncTask can be considered only for short tasks (less than 1 second). However, using IntentService (or AsyncTaskLoader) can avoid such problems since their lifecycles are independent from `Activity`/`Fragment`.

In `OpenTripPlanner-for-Android`, most of the AsyncTasks hold weak reference to an activity. It doesn't result in memory leak but may lead to wasting task result (when weak reference is GCed and points to null). Why not use IntentService instead, so that the BroadcastReceiver can hold a strong reference to activity while also avoid memory leak?

I refactored 3 AsyncTasks in `OpenTripPlanner-for-Android ` to IntentService (in 3 commits), with the help of a refactoring tool we developed. Do you think using IntentService should be better in some of these 3 scenario? Do you want to merge (some) commits in this pr? Thanks.