### PR TITLE
Fix #486 MetadataRequest/remove busish+trainish mode for current OTP version

### DIFF
--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/OTPApp.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/OTPApp.java
@@ -50,7 +50,17 @@ public class OTPApp extends Application {
 
     public static final String SERVER_INFO_LOCATION_NEW = "";
 
+    /** Since OTP version 0.11 (API_VERSION_v1), duration is published in seconds, before in ms */
     public static final int API_VERSION_MINOR_011 = 11;
+
+    /** Since OTP version 0.19 (API_VERSION_v2), router metadata is published via /routers/default endpoint */
+    public static final int API_VERSION_MINOR_019 = 19;
+
+    /** Since OTP version 1.0.0 (API_VERSION_v3), busish and trainish modes are not supported any more */
+    public static final int API_VERSION_V3 = 3;
+
+    /** Since OTP version 0.19 (API_VERSION_v2), router metadata is published via /routers/default endpoint */
+    public static final int API_VERSION_V2 = 2;
 
     public static final int API_VERSION_V1 = 1;
 

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/DirectionListFragment.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/DirectionListFragment.java
@@ -169,16 +169,7 @@ public class DirectionListFragment extends ExpandableListFragment {
 
         for (int i = 0; i < itinerarySummaryList.length; i++) {
             Itinerary it = itineraryList.get(i);
-            long tripDuration;
-            if (PreferenceManager.getDefaultSharedPreferences(
-                    getActivity().getApplicationContext())
-                    .getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V1)
-                    == OTPApp.API_VERSION_V1){
-                tripDuration = it.duration;
-            }
-            else{
-                tripDuration = it.duration / 1000;
-            }
+            long tripDuration = ConversionUtils.normalizeDuration(it.duration, getActivity().getApplicationContext());
             itinerarySummaryList[i] += getString(R.string.step_by_step_total_duration) + " " + ConversionUtils
                     .getFormattedDurationTextNoSeconds(tripDuration, false,
                             getActivity().getApplicationContext());

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/fragments/MainFragment.java
@@ -3146,13 +3146,7 @@ public class MainFragment extends Fragment implements
         CharSequence snippet;
         long legDuration;
         TraverseMode traverseMode = TraverseMode.valueOf(leg.mode);
-
-        if (mPrefs.getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V1)
-                == OTPApp.API_VERSION_V1){
-            legDuration = leg.duration;
-        } else{
-            legDuration = leg.duration / 1000;
-        }
+        legDuration = ConversionUtils.normalizeDuration(leg.duration, mPrefs);
         if (traverseMode.isTransit()) {
             CharSequence spannableSnippet = ConversionUtils
                     .getTimeWithContext(mApplicationContext, leg.agencyTimeZoneOffset,
@@ -3392,13 +3386,7 @@ public class MainFragment extends Fragment implements
         for (int i = 0; i < itinerarySummaryList.length; i++) {
             boolean isTransitIsTagSet = false;
             Itinerary it = itineraryList.get(i);
-            if (mPrefs.getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V1)
-                    == OTPApp.API_VERSION_V1){
-                tripDuration = it.duration;
-            }
-            else{
-                tripDuration = it.duration / 1000;
-            }
+            tripDuration = ConversionUtils.normalizeDuration(it.duration, mPrefs);
             for (Leg leg : it.legs) {
                 TraverseMode traverseMode = TraverseMode.valueOf(leg.mode);
                 if (traverseMode.isTransit()) {

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/MetadataRequest.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/MetadataRequest.java
@@ -24,6 +24,7 @@ import org.opentripplanner.api.ws.GraphMetadata;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -78,10 +79,16 @@ public class MetadataRequest extends AsyncTask<String, Integer, GraphMetadata> {
     }
 
     protected GraphMetadata doInBackground(String... reqs) {
-        String prefix = PreferenceManager.getDefaultSharedPreferences(context)
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String prefix = prefs
                 .getString(OTPApp.PREFERENCE_KEY_FOLDER_STRUCTURE_PREFIX
                         , OTPApp.FOLDER_STRUCTURE_PREFIX_NEW);
-        String u = reqs[0] + prefix + OTPApp.METADATA_LOCATION;
+        String u = reqs[0] + prefix ;
+
+        if (prefs.getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V2)
+                < OTPApp.API_VERSION_V2) {
+            u += OTPApp.METADATA_LOCATION;
+        }
         Log.d(OTPApp.TAG, "URL: " + u);
 
         HttpURLConnection urlConnection = null;

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/ServerChecker.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/ServerChecker.java
@@ -195,10 +195,14 @@ public class ServerChecker extends AsyncTask<Server, Long, String> {
             }
 
             if (serverInfo != null){
-                int api_version = serverInfo.serverVersion.major;
+                int api_version = OTPApp.API_VERSION_V3;
                 if (serverInfo.serverVersion.major == 0){
-                    if (serverInfo.serverVersion.minor == OTPApp.API_VERSION_MINOR_011){
+                    if (serverInfo.serverVersion.minor >= OTPApp.API_VERSION_MINOR_019){
+                        api_version = OTPApp.API_VERSION_V2;
+                    }else if (serverInfo.serverVersion.minor >= OTPApp.API_VERSION_MINOR_011){
                         api_version = OTPApp.API_VERSION_V1;
+                    }else {
+                        api_version = OTPApp.API_VERSION_PRE_V1;
                     }
                 }
                 prefsEditor.putInt(OTPApp.PREFERENCE_KEY_API_VERSION,

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/TripRequest.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/tasks/TripRequest.java
@@ -28,6 +28,7 @@ import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -273,6 +274,23 @@ public class TripRequest extends AsyncTask<Request, Integer, Long> {
             }
 
             params = updatedString;
+        }
+
+
+        if (requestParams.getModes().getTrainish()) {
+            // TraverseModeSet.toString() enumerates activated modes, which might not be supported by server
+            // so we filter them out. Should be solved differently, e.g. by  decoupling and introducing
+            // an interface with version dependent implementations
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+            if (prefs.getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V3)
+                    >= OTPApp.API_VERSION_V3) {
+                String updatedString;
+                updatedString = params.replace(TraverseMode.TRAINISH.toString(), "");
+                updatedString = updatedString.replace(TraverseMode.BUSISH.toString(), "");
+
+                params = updatedString;
+            }
         }
 
         String u = baseURL + prefix + OTPApp.PLAN_LOCATION + params;

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/util/ConversionUtils.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/util/ConversionUtils.java
@@ -66,14 +66,7 @@ public class ConversionUtils {
 
         duration = 0;
         if (startTime != null && endTime != null) {
-            if (PreferenceManager.getDefaultSharedPreferences(applicationContext)
-                    .getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V1)
-                    == OTPApp.API_VERSION_V1){
-                duration = (endTime.getTime() - startTime.getTime());
-            }
-            else{
-                duration = (endTime.getTime() - startTime.getTime()) / 1000;
-            }
+            duration = normalizeDuration(endTime.getTime() - startTime.getTime(), applicationContext) ;
         }
         return duration;
     }
@@ -463,4 +456,15 @@ public class ConversionUtils {
         return prefs.getString(OTPApp.PREFERENCE_KEY_MAP_TILE_SOURCE, defaultOverlay);
     }
 
+    public static long normalizeDuration(long duration, Context context) {
+        return normalizeDuration(duration, PreferenceManager.getDefaultSharedPreferences(context));
+    }
+
+    public static long normalizeDuration(long duration, SharedPreferences prefs) {
+        if (prefs.getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V1)
+                < OTPApp.API_VERSION_V1){
+            return duration / 1000;
+        }
+        return duration;
+    }
 }

--- a/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/util/DirectionsGenerator.java
+++ b/opentripplanner-android/src/main/java/edu/usf/cutr/opentripplanner/android/util/DirectionsGenerator.java
@@ -26,9 +26,7 @@ import org.opentripplanner.api.model.Place;
 import org.opentripplanner.api.model.WalkStep;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.preference.PreferenceManager;
 import android.text.SpannableString;
 import android.text.TextUtils;
 
@@ -37,7 +35,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-import edu.usf.cutr.opentripplanner.android.OTPApp;
 import edu.usf.cutr.opentripplanner.android.R;
 import edu.usf.cutr.opentripplanner.android.model.Direction;
 
@@ -157,13 +154,7 @@ public class DirectionsGenerator {
                         + getLocalizedStreetName(toPlace.name, applicationContext.getResources());
         String extraStopInformation = toPlace.stopCode;
         long legDuration;
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext);
-        if (prefs.getInt(OTPApp.PREFERENCE_KEY_API_VERSION, OTPApp.API_VERSION_V1)
-                == OTPApp.API_VERSION_V1){
-            legDuration = leg.duration;
-        } else{
-            legDuration = leg.duration / 1000;
-        }
+        legDuration = ConversionUtils.normalizeDuration(leg.duration, applicationContext);
         if (!TextUtils.isEmpty(extraStopInformation)) {
             mainDirectionText += " (" + extraStopInformation + ")";
         }


### PR DESCRIPTION
This PR adds API_VERSION_v2 (routers/default is metadata endpoint since OTP0.19) and API_VERSION_v3 (since 1.0.0 busish and trainish modes are not supported any more and cause 404 errors when requested).
 
New versions are just added as new constants. In future, a version dependend strategy would be a better approach to handle API differences. 