### PR TITLE
How about turning on the Travis CI Cache feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@
 
 language: android
 jdk: oraclejdk8
-# Turn off caching to avoid any caching problems
-cache: false
+cache:
+   directories:
+   - $HOME/.gradle/caches/
+   - $HOME/.gradle/wrapper/
 # Use the Travis Container-Based Infrastructure
 sudo: false
 env:


### PR DESCRIPTION
 [Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.
